### PR TITLE
docs: add live wip demo link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Demo
 
-Live WIP demo available soon
+View the Live WIP Demo at: [event-notification-app.vercel.app](https://event-notification-app.vercel.app/)
 
 ## Clone and run locally
 


### PR DESCRIPTION
Adding live WIP demo link to readme after deploying to Vercel.